### PR TITLE
Fiks for scrolling i H5P

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,7 +1,11 @@
 body {
-	margin: 0;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+  margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+  // Fix for scrolling i H5P iframe
+  overflow-y: scroll;
+  height: 100vh !important;
 }
 
 @import '~@ndla/core/scss/core';


### PR DESCRIPTION
Innholdet scrollet ikke når det kjørte i H5P iframe. Dette skyldes at H5P iframe har slått av scrolling vha scrolling="no" attributten.

Løst ved å sette overflow-y: scroll og en høyde på 100vh på body-taggen.